### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ You will need:
 Once you are able to build the server and its plugins, you can build
 the SMTP plugin. Within the `rabbitmq-public-umbrella` directory,
 
-    hg clone http://hg.rabbitmq.com/rabbitmq-smtp
+    hg clone https://hg.rabbitmq.com/rabbitmq-smtp
     cd rabbitmq-smtp
     make
 
 At this point, the `Makefile` will retrieve a copy of
-[erlang-smtp](http://hg.opensource.lshift.net/erlang-smtp/) if it
+[erlang-smtp](https://bitbucket.org/lshift/erlang-smtp/) if it
 hasn't done so already. It will then compile everything, resulting (if
 all goes well) in the presence of
 `rabbitmq-smtp/dist/rabbitmq-smtp.ez` and
@@ -72,7 +72,7 @@ and `tonyg-foo@rabbitmq.com` is mapped to
 
 The plugin is configured using the normal Erlang application
 configuration mechanism. RabbitMQ has a [standard configuration
-file](http://www.rabbitmq.com/install.html#configfile) that can be
+file](https://www.rabbitmq.com/install.html#configfile) that can be
 used to configure the plugin. The application name is
 `rabbitmq_smtp_server`, and the individual keys are described below.
 
@@ -144,4 +144,4 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-  [pluginguide]: http://www.rabbitmq.com/plugin-development.html
+  [pluginguide]: https://www.rabbitmq.com/plugin-development.html


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://hg.rabbitmq.com/rabbitmq-smtp (UnknownHostException) with 1 occurrences migrated to:  
  https://hg.rabbitmq.com/rabbitmq-smtp ([https](https://hg.rabbitmq.com/rabbitmq-smtp) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://hg.opensource.lshift.net/erlang-smtp/ (301) with 1 occurrences migrated to:  
  https://bitbucket.org/lshift/erlang-smtp/ ([https](https://hg.opensource.lshift.net/erlang-smtp/) result 200).
* http://www.rabbitmq.com/plugin-development.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/plugin-development.html ([https](https://www.rabbitmq.com/plugin-development.html) result 200).
* http://www.rabbitmq.com/install.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/install.html ([https](https://www.rabbitmq.com/install.html) result 301).